### PR TITLE
MonoDevelop用のコーディング規約ポリシーを追加

### DIFF
--- a/Tools/MonoDevelop/README.md
+++ b/Tools/MonoDevelop/README.md
@@ -1,0 +1,4 @@
+- これはVERVEコーディング規約に則ったMonoDevelop用のポリシーファイルです。
+- MonoDevelopへの適用の方法は、下記URLのサイトを参照して下さい。
+ - https://github.com/uzzu/monodevelop-codingstyle4csharp
+

--- a/Tools/MonoDevelop/VerveCodingStyle.mdpolicy
+++ b/Tools/MonoDevelop/VerveCodingStyle.mdpolicy
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PolicySet name="VerveCodingStyle">
+  <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp">
+    <FileWidth>100</FileWidth>
+    <EolMarker>Unix</EolMarker>
+  </TextStylePolicy>
+  <CSharpFormattingPolicy inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp">
+    <IndentSwitchBody>True</IndentSwitchBody>
+    <StructBraceStyle>EndOfLine</StructBraceStyle>
+    <EnumBraceStyle>EndOfLine</EnumBraceStyle>
+    <MethodBraceStyle>EndOfLine</MethodBraceStyle>
+    <ConstructorBraceStyle>EndOfLine</ConstructorBraceStyle>
+    <DestructorBraceStyle>EndOfLine</DestructorBraceStyle>
+    <BeforeMethodDeclarationParentheses>False</BeforeMethodDeclarationParentheses>
+    <BeforeMethodCallParentheses>False</BeforeMethodCallParentheses>
+    <BeforeConstructorDeclarationParentheses>False</BeforeConstructorDeclarationParentheses>
+    <BeforeIndexerDeclarationBracket>False</BeforeIndexerDeclarationBracket>
+    <BeforeDelegateDeclarationParentheses>False</BeforeDelegateDeclarationParentheses>
+    <NewParentheses>False</NewParentheses>
+    <SpacesBeforeBrackets>False</SpacesBeforeBrackets>
+    <MethodCallArgumentWrapping>WrapIfTooLong</MethodCallArgumentWrapping>
+    <NewLineAferMethodCallOpenParentheses>NewLine</NewLineAferMethodCallOpenParentheses>
+    <MethodCallClosingParenthesesOnNewLine>NewLine</MethodCallClosingParenthesesOnNewLine>
+    <MethodDeclarationParameterWrapping>WrapIfTooLong</MethodDeclarationParameterWrapping>
+    <NewLineAferMethodDeclarationOpenParentheses>NewLine</NewLineAferMethodDeclarationOpenParentheses>
+    <MethodDeclarationClosingParenthesesOnNewLine>NewLine</MethodDeclarationClosingParenthesesOnNewLine>
+    <AlignToFirstMethodDeclarationParameter>False</AlignToFirstMethodDeclarationParameter>
+    <IndexerDeclarationParameterWrapping>WrapIfTooLong</IndexerDeclarationParameterWrapping>
+    <NewLineAferIndexerDeclarationOpenBracket>NewLine</NewLineAferIndexerDeclarationOpenBracket>
+    <IndexerDeclarationClosingBracketOnNewLine>NewLine</IndexerDeclarationClosingBracketOnNewLine>
+    <AlignToFirstIndexerDeclarationParameter>False</AlignToFirstIndexerDeclarationParameter>
+    <IndexerArgumentWrapping>WrapIfTooLong</IndexerArgumentWrapping>
+    <NewLineAferIndexerOpenBracket>NewLine</NewLineAferIndexerOpenBracket>
+    <IndexerClosingBracketOnNewLine>NewLine</IndexerClosingBracketOnNewLine>
+  </CSharpFormattingPolicy>
+  <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/plain">
+    <FileWidth>120</FileWidth>
+    <EolMarker>Unix</EolMarker>
+  </TextStylePolicy>
+  <DotNetNamingPolicy>
+    <DirectoryNamespaceAssociation>None</DirectoryNamespaceAssociation>
+    <ResourceNamePolicy>FileFormatDefault</ResourceNamePolicy>
+  </DotNetNamingPolicy>
+  <StandardHeader>
+    <Text />
+    <IncludeInNewFiles>True</IncludeInNewFiles>
+  </StandardHeader>
+  <NameConventionPolicy>
+    <Rules>
+      <NamingRule>
+        <Name>Namespaces</Name>
+        <AffectedEntity>Namespace</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Types</Name>
+        <AffectedEntity>Class, Struct, Enum, Delegate</AffectedEntity>
+        <VisibilityMask>Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Interfaces</Name>
+        <RequiredPrefixes>
+          <String>I</String>
+        </RequiredPrefixes>
+        <AffectedEntity>Interface</AffectedEntity>
+        <VisibilityMask>Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Attributes</Name>
+        <RequiredSuffixes>
+          <String>Attribute</String>
+        </RequiredSuffixes>
+        <AffectedEntity>CustomAttributes</AffectedEntity>
+        <VisibilityMask>Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Event Arguments</Name>
+        <RequiredSuffixes>
+          <String>EventArgs</String>
+        </RequiredSuffixes>
+        <AffectedEntity>CustomEventArgs</AffectedEntity>
+        <VisibilityMask>Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Exceptions</Name>
+        <RequiredSuffixes>
+          <String>Exception</String>
+        </RequiredSuffixes>
+        <AffectedEntity>CustomExceptions</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Methods</Name>
+        <AffectedEntity>Methods</AffectedEntity>
+        <VisibilityMask>Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Static Readonly Fields</Name>
+        <AffectedEntity>ReadonlyField</AffectedEntity>
+        <VisibilityMask>Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>False</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Fields</Name>
+        <AffectedEntity>Field</AffectedEntity>
+        <VisibilityMask>Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>ReadOnly Fields</Name>
+        <AffectedEntity>ReadonlyField</AffectedEntity>
+        <VisibilityMask>Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>False</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Constant Fields</Name>
+        <AffectedEntity>ConstantField</AffectedEntity>
+        <VisibilityMask>Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Properties</Name>
+        <AffectedEntity>Property</AffectedEntity>
+        <VisibilityMask>Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Events</Name>
+        <AffectedEntity>Event</AffectedEntity>
+        <VisibilityMask>Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Enum Members</Name>
+        <AffectedEntity>EnumMember</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Parameters</Name>
+        <AffectedEntity>Parameter</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>CamelCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Type Parameters</Name>
+        <RequiredPrefixes>
+          <String>T</String>
+        </RequiredPrefixes>
+        <AffectedEntity>TypeParameter</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+    </Rules>
+  </NameConventionPolicy>
+</PolicySet>


### PR DESCRIPTION
- 各種ツール向けの設定ファイルの置き場所を作成。
- 最初のサンプルとしてMonoDevelop用のポリシーファイルを追加。
